### PR TITLE
Implement new commands (import/export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ definition-folder
 |-- code
 |   |-- my_step.js
 |-- form
-    |-- definition.json
+    |-- my_step.json
 ```
 
 To take advantage of the base64 encoding component of `stitch`, you'll need to name your JavaScript files located inside 
@@ -70,17 +70,38 @@ module.exports = function(context) {
 ## Commands
 
 ```sh
-stitch path/to/directory
-
+Usage: stitch [options] [command]
+           
 Options:
-  -i, --insomnia  Escape for use in insomnia
-  -h, --help      output usage information
+  -h, --help                  output usage information
+                                                     
+Commands:
+  import <definition> <path>  Import an already exported definition to be expanded
+  export [options] <dir>      Export a definition to be weaved together
 ```
+
+#### Import
+
+Expands an existing definition and writes to the `destination`
+
+`stitch import "$(< file.json)" <destination>`
+
+
+#### Export
+
+Export a definition from the supplied `dir`
+
+`stitch export <dir>`
+
+---
 
 ### Examples
 
-#### Print to file
-`stitch path/to/directory > result.json`
+#### Export directory and print to file
+`stitch export path/to/directory > result.json`
 
-#### Copy to clipbaord (macOS)
-`stitch path/to/directory | pbcopy`
+#### Export directory and copy to clipboard (macOS)
+`stitch export path/to/directory | pbcopy`
+
+#### Import file from input
+`stitch import "$(< file.json)" <destination>`

--- a/app.js
+++ b/app.js
@@ -7,11 +7,17 @@ const printer = require("./src/printer");
 
 commander.version(packageJson.version);
 
-commander
-  .description("Stitch em")
-  .action(run.bind({}, commandStitch))
-  .option("-i, --insomnia", "Escape for use in insomnia")
-  .arguments("<dir>");
+commander.command('import').
+    description('Import an already exported definition to be expanded').
+    action(run.bind({}, commandImport)).
+    arguments('<definition>').
+    arguments('<path>');
+
+commander.command('export').
+    description('Export a definition to be weaved together').
+    action(run.bind({}, commandExport)).
+    option('-i, --insomnia', 'Escape for use in insomnia').
+    arguments('<dir>');
 
 commander.parse(process.argv);
 
@@ -30,15 +36,24 @@ function run(action, ...args) {
 }
 
 /**
+ * @param {string} definition
+ * @param {string} path
+ * @returns {Promise<void>}
+ */
+async function commandImport(definition, path) {
+  await stitch.createExpandedDefinition(JSON.parse(definition), path);
+}
+
+/**
  * @param {string} path
  * @param {Object} cmd
  * @param {undefined|Boolean} cmd.insomnia
  * @returns {Promise<void>}
  */
-async function commandStitch(path, cmd) {
+async function commandExport(path, cmd) {
   printer.insomnia = cmd.insomnia || false;
 
   printer.output(
-    await stitch.createStitchedDefinition(path)
+      await stitch.createStitchedDefinition(path),
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rexlabs/stitch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "app.js",
   "description": "Stitch together JSON definitions",
   "authors": [

--- a/src/printer.js
+++ b/src/printer.js
@@ -35,18 +35,19 @@ module.exports = {
    * Write to file
    *
    * @param {String} dir
-   * @param {Object} definition
+   * @param {String} fileName
+   * @param {Object} output
    * @returns {Promise<void>}
    */
-  write: async function(dir, definition) {
+  write: async function(dir, fileName, output) {
     // Ensure dir (ok if already exists)
     try {
-      await fs.mkdirp(`${process.cwd()}/gen/${dir}`);
+      await fs.mkdirp(dir);
     } catch (err) {
     }
 
     try {
-      await fs.writeFile(`${process.cwd()}/gen/${dir}/definition.json`, this.getText(definition), {
+      await fs.writeFile(`${dir}/${fileName}`, output, {
         flag: "w"
       });
     } catch (err) {


### PR DESCRIPTION
This pull request implements new functionality and refactors some of the old code to instead be used as a separate command.

`stitch` now becomes `stitch export`, along with a new command `stitch import`.

`stitch import` allows for the end-user to supply a `<file>`'s contents as the first argument and a `<destination` as the second argument.

When `stitch import` is run, it will take an existing `export`ed definition and disassemble it into its appropriate parts (`code`/`forms` folders, along with `definition.json`) so that the end-user can read and reconstruct if they wish to. 